### PR TITLE
Add valid parameters for tasks route

### DIFF
--- a/lib/scaleapi.js
+++ b/lib/scaleapi.js
@@ -82,12 +82,14 @@ ScaleClient.prototype.cancelTask = function(taskId, cb) {
  * @param {string} params.end_time - ISO date representing end of date range
  * @param {string} params.status - fetch only tasks with status: 'completed', 'pending', or 'canceled'
  * @param {string} params.type - fetch only tasks of this type
+ * @param {string} params.project - fetch only tasks of this project
+ * @param {string} params.batch - fetch only tasks of this batch
  * @param {Number} params.limit - max number of results
  * @param {Number} params.offset - number of results to skip
  * @param {function} cb - callback called with (err, tasks)
  */
 ScaleClient.prototype.tasks = function(params, cb) {
-  var allowedKwargs = ['start_time', 'end_time', 'status', 'type', 'limit', 'offset'];
+  var allowedKwargs = ['start_time', 'end_time', 'status', 'type', 'project', 'batch', 'limit', 'offset'];
   Object.keys(params).forEach(property => {
     if (allowedKwargs.indexOf(property) < 0) {
       cb && cb(

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "name": "scaleapi",
   "description": "Official Node SDK for Scale API",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "lib/scaleapi.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
`project` and `batch` are valid parameters for the `tasks` route ([API doc](https://scale.ai/docs#list-all-tasks)). However, currently they are rejected on the client side. This PR fixes it.
